### PR TITLE
typo waight -> weight

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -259,7 +259,7 @@ export const componentsTheme = {
         minWidth: "110px",
         textAlign: "center",
         fontSize: values.text.size.middle,
-        fontWeight: values.font.waight.bold,
+        fontWeight: values.font.weight.bold,
       },
       check: {
         width: "18px",
@@ -482,7 +482,7 @@ export const componentsTheme = {
       backgroundColor: color.solitude,
       textAlign: "left",
       fontSize: values.text.size.middle,
-      fontWeight: values.font.waight.bold,
+      fontWeight: values.font.weight.bold,
     },
     td: {
       padding: "10px 17px",
@@ -490,8 +490,8 @@ export const componentsTheme = {
       textAlign: "left",
       fontSize: values.text.size.middle,
       fontWeight: {
-        normal: values.font.waight.normal,
-        bold: values.font.waight.bold,
+        normal: values.font.weight.normal,
+        bold: values.font.weight.bold,
       },
     },
   },

--- a/src/theme/values.ts
+++ b/src/theme/values.ts
@@ -3,7 +3,7 @@ import { color } from "./color";
 export const values = {
   font: {
     noto: "Noto Sans JP",
-    waight: {
+    weight: {
       normal: "normal",
       bold: "bold",
     },


### PR DESCRIPTION
利用しようとしたところ誤字を発見したため対応

他のプロダクトで`values.font.waight`を使っていた場合影響出るので注意が必要