### PR TITLE
exportされていなくてNotificationが使用できないので修正

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./Heading";
 export * from "./Icon";
 export * from "./Link";
 export * from "./Modal";
+export * from "./Notification";
 export * from "./Pagination";
 export * from "./ProgressLabel";
 export * from "./Radio";


### PR DESCRIPTION
Notificationを使用しようと思ったら、Notificationがexportされていなくて使用できなかったので修正します。