### PR TITLE
CheckboxとRadioにchecked propsを追加

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import { defaultProps } from "../../theme";
 
 export type Props = {
   name?: string;
+  checked?: boolean;
   defaultChecked?: boolean;
   disabled?: boolean;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,4 +1,5 @@
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { useState } from "react";
 import { Checkbox } from "../Checkbox";
 
 describe("Checkbox", () => {
@@ -35,5 +36,26 @@ describe("Checkbox", () => {
 
     expect(onChange).toBeCalledTimes(1);
     expect(onClick).toBeCalledTimes(1);
+  });
+
+  it("checked, onChange props", () => {
+    const TestForm = () => {
+      const [checked, setChecked] = useState(false);
+      const handleChange = () => {
+        setChecked((prev) => !prev);
+      };
+
+      return (
+        <Checkbox checked={checked} onChange={handleChange}>
+          checkbox
+        </Checkbox>
+      );
+    };
+
+    render(<TestForm />);
+
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    fireEvent.click(screen.getByText("checkbox"));
+    expect(screen.getByRole("checkbox")).toBeChecked();
   });
 });

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -4,6 +4,7 @@ import { defaultProps } from "../../theme";
 
 export type Props = {
   name?: string;
+  checked?: boolean;
   defaultChecked?: boolean;
   value?: string;
   disabled?: boolean;

--- a/src/components/Radio/__tests__/Radio.test.tsx
+++ b/src/components/Radio/__tests__/Radio.test.tsx
@@ -1,4 +1,5 @@
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { useState } from "react";
 import { Radio } from "../Radio";
 
 describe("Radio", () => {
@@ -33,5 +34,26 @@ describe("Radio", () => {
 
     expect(onChange).toBeCalledTimes(1);
     expect(onClick).toBeCalledTimes(1);
+  });
+
+  it("checked, onChange props", () => {
+    const TestForm = () => {
+      const [checked, setChecked] = useState(false);
+      const handleChange = () => {
+        setChecked((prev) => !prev);
+      };
+
+      return (
+        <Radio checked={checked} onChange={handleChange}>
+          radio
+        </Radio>
+      );
+    };
+
+    render(<TestForm />);
+
+    expect(screen.getByRole("radio")).not.toBeChecked();
+    fireEvent.click(screen.getByText("radio"));
+    expect(screen.getByRole("radio")).toBeChecked();
   });
 });


### PR DESCRIPTION
CheckboxとRadioにchecked propsを追加しました。
使いどころとして、Checkboxのchecked状態をuseStateで管理して、onChangeイベントで制御したい場面ができたからです。
Radioは同じようなコンポーネントなのでついでに対応しました、