### PR TITLE
Start to update libraries by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: Asia/Tokyo
+    versioning-strategy: increase


### PR DESCRIPTION
https://docs.github.com/ja/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates

`rebase-strategy: "disabled"` にはしておらず、dependabotがopenしているPRがあるときに他のPRがマージされると自動でrebaseされますが、PR数は5つ(default)であまり影響はないと思ったので設定していません。（数が多そうであればあとで変更します）