### PR TITLE
ラジオボタンのdisabled時の振る舞いを修正する

### DIFF
--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -8,7 +8,11 @@ export default {
 
 const Template: Story<Props> = (args) => <Radio {...args}>Radio</Radio>;
 
-export const Default = Template.bind({});
+export const Default = Template.bind({
+  id: 'radio-1',
+  name: 'default',
+  value: 'value-1',
+});
 
 export const Disabled = Template.bind({});
-Disabled.args = { disabled: true };
+Disabled.args = { disabled: true, id: 'radio-2', name: 'disabled' };

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -9,6 +9,11 @@ export default {
     onClick: { action: 'clicked' },
     onChange: { action: 'changed' },
   },
+  parameters: {
+    backgrounds: {
+      disable: true,
+    },
+  },
 } as Meta;
 
 const Wrapper = styled.div`

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,19 +1,49 @@
 import { Story, Meta } from '@storybook/react';
 import { Radio, Props } from './Radio';
+import styled from 'styled-components';
 
 export default {
   component: Radio,
   title: 'components/Radio',
+  argTypes: {
+    onClick: { action: 'clicked' },
+    onChange: { action: 'changed' },
+  },
 } as Meta;
 
-const Template: Story<Props> = (args) => <Radio {...args}>Radio</Radio>;
+const Wrapper = styled.div`
+  display: flex;
+  column-gap: 10px;
+`;
+
+const Template: Story<Props> = ({ id, name, onClick, onChange, ...args }) => (
+  <Wrapper>
+    <Radio
+      id="radio-1"
+      name={name}
+      onClick={onClick}
+      onChange={onChange}
+      {...args}
+    >
+      Radio 1
+    </Radio>
+    <Radio
+      id="radio-2"
+      name={name}
+      onClick={onClick}
+      onChange={onChange}
+      value="second"
+    >
+      Radio 2
+    </Radio>
+  </Wrapper>
+);
 
 export const Default = Template.bind({});
 Default.args = {
-  id: 'radio-1',
   name: 'default',
   value: 'value-1',
 };
 
 export const Disabled = Template.bind({});
-Disabled.args = { disabled: true, id: 'radio-2', name: 'disabled' };
+Disabled.args = { disabled: true, name: 'disabled' };

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -8,11 +8,12 @@ export default {
 
 const Template: Story<Props> = (args) => <Radio {...args}>Radio</Radio>;
 
-export const Default = Template.bind({
+export const Default = Template.bind({});
+Default.args = {
   id: 'radio-1',
   name: 'default',
   value: 'value-1',
-});
+};
 
 export const Disabled = Template.bind({});
 Disabled.args = { disabled: true, id: 'radio-2', name: 'disabled' };

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -12,6 +12,7 @@ export type Props = {
   onClick?: (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
   children?: React.ReactNode;
   className?: string;
+  id: string;
 };
 
 const RadioWrapper = styled.span`
@@ -28,23 +29,23 @@ RadioWrapper.defaultProps = defaultProps;
 
 const Input = styled.input`
   ${({ theme: { radio } }) => css`
-    opacity: 0;
+    /* opacity: 0;
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     margin: 0;
-    cursor: pointer;
+    cursor: pointer; */
 
-    :checked + ${Box} {
+    :checked + ${RadioButton} {
       background-color: ${radio.backgroundColor.checked};
       border-width: ${radio.borderWidth.checked};
       border-style: ${radio.borderStyle.checked};
       border-color: ${radio.borderColor.checked};
     }
 
-    :disabled + ${Box} {
+    :disabled + ${RadioButton} {
       background-color: ${radio.backgroundColor.disabled};
       border-width: ${radio.borderWidth.disabled};
       border-style: ${radio.borderStyle.disabled};
@@ -54,21 +55,21 @@ const Input = styled.input`
 `;
 Input.defaultProps = defaultProps;
 
-const Box = styled.span`
+const RadioButton = styled.span`
   ${({ theme: { radio } }) => css`
-    position: absolute;
+    /* position: absolute;
     width: 100%;
-    height: 100%;
+    height: 100%; */
     border-radius: ${radio.borderRadius};
     background-color: ${radio.backgroundColor.unchecked};
     border-width: ${radio.borderWidth.unchecked};
     border-style: ${radio.borderStyle.unchecked};
     border-color: ${radio.borderColor.unchecked};
-    pointer-events: none;
+    /* pointer-events: none; */
     box-sizing: border-box;
   `}
 `;
-Box.defaultProps = defaultProps;
+RadioButton.defaultProps = defaultProps;
 
 const IconWrapper = styled.span`
   ${({ theme: { radio } }) => css`
@@ -79,7 +80,7 @@ const IconWrapper = styled.span`
     width: ${radio.icon.width};
     height: ${radio.icon.height};
     transform: translate(-50%, -50%);
-    pointer-events: none;
+    /* pointer-events: none; */
 
     & > svg {
       vertical-align: top;
@@ -123,17 +124,27 @@ const Label = styled.label`
 const LabelText = styled.span``;
 
 const Radio = forwardRef<HTMLInputElement, Props>(
-  ({ children, className, ...rest }, ref) => (
-    <Label>
-      <RadioWrapper className={className}>
-        <Input type="radio" ref={ref} {...rest} />
-        <Box />
+  ({ children, className, id, ...rest }, ref) => (
+    // <Label>
+    //   <RadioWrapper className={className}>
+    //     <Input type="radio" ref={ref} {...rest} />
+    //     <Box />
+    //     <IconWrapper>
+    //       <Icon />
+    //     </IconWrapper>
+    //   </RadioWrapper>
+    //   <LabelText>{children}</LabelText>
+    // </Label>
+    <div>
+      <Input type="radio" id={id} ref={ref} {...rest} />
+      <Label htmlFor={id}>
+        <RadioButton />
         <IconWrapper>
           <Icon />
         </IconWrapper>
-      </RadioWrapper>
-      <LabelText>{children}</LabelText>
-    </Label>
+        <LabelText>{children}</LabelText>
+      </Label>
+    </div>
   )
 );
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -39,60 +39,25 @@ const RadioButton = styled.span`
   margin-right: 4px;
 
   ${({ theme: { radio } }) => css`
-    --radio-bg-color: ${radio.backgroundColor.unchecked};
+    --radio-state-color: ${radio.backgroundColor.unchecked};
 
     width: 16px;
     height: 16px;
     border-radius: ${radio.borderRadius};
-    background-color: var(--radio-bg-color);
-    border: 1px solid var(--radio-bg-color);
+    background-color: #fff;
+    border: 5px solid var(--radio-state-color);
     box-sizing: border-box;
 
     ${Input}:checked + ${Label} > & {
-      --radio-bg-color: ${radio.backgroundColor.checked};
+      --radio-state-color: ${radio.backgroundColor.checked};
     }
 
     ${Input}:disabled + ${Label} > & {
-      --radio-bg-color: ${radio.backgroundColor.disabled};
+      --radio-state-color: ${radio.backgroundColor.disabled};
     }
   `}
 `;
 RadioButton.defaultProps = defaultProps;
-
-const IconWrapper = styled.span`
-  ${({ theme: { radio } }) => css`
-    display: inline-block;
-    width: ${radio.icon.width};
-    height: ${radio.icon.height};
-
-    & > svg {
-      vertical-align: top;
-    }
-  `}
-`;
-IconWrapper.defaultProps = defaultProps;
-
-const Icon = styled(({ className }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 6 6"
-    className={className}
-    aria-hidden="true"
-  >
-    <circle
-      cx="102"
-      cy="546"
-      r="3"
-      fillRule="evenodd"
-      transform="translate(-99 -543)"
-    />
-  </svg>
-))`
-  ${({ theme: { radio } }) => css`
-    fill: ${radio.icon.color};
-  `}
-`;
-Icon.defaultProps = defaultProps;
 
 const Label = styled.label`
   cursor: pointer;
@@ -112,11 +77,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
     <RadioWrapper>
       <Input type="radio" id={id} ref={ref} {...rest} />
       <Label htmlFor={id}>
-        <RadioButton>
-          <IconWrapper>
-            <Icon />
-          </IconWrapper>
-        </RadioButton>
+        <RadioButton />
         <LabelText>{children}</LabelText>
       </Label>
     </RadioWrapper>

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -92,7 +92,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
         {...rest}
       />
       <Label htmlFor={id}>
-        <RadioButton />
+        <RadioButton aria-hidden="true" />
         <LabelText>{children}</LabelText>
       </Label>
     </RadioWrapper>

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -64,7 +64,6 @@ const IconWrapper = styled.span`
     display: inline-block;
     width: ${radio.icon.width};
     height: ${radio.icon.height};
-    /* pointer-events: none; */
 
     & > svg {
       vertical-align: top;
@@ -99,6 +98,11 @@ const Label = styled.label`
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+
+  ${Input}:disabled + & {
+    cursor: not-allowed;
+    color: #999;
+  }
 `;
 
 const LabelText = styled.span``;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -60,7 +60,6 @@ const Label = styled.label`
     color: #999;
   }
 `;
-
 const LabelText = styled.span``;
 
 const Radio = forwardRef<HTMLInputElement, Props>(

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -29,16 +29,17 @@ const InputContainer = styled.div`
   align-items: center;
 
   ${({ theme: { radio } }) => css`
-    --radio-state-color: ${radio.backgroundColor.unchecked};
+    --radio-background-color: ${radio.backgroundColor.unchecked};
+    --radio-border-color: ${radio.borderColor.unchecked};
 
     ${Input}:checked + & {
-      --radio-state-color: ${radio.backgroundColor.checked};
+      --radio-background-color: ${radio.backgroundColor.checked};
+      --radio-border-color: ${radio.borderColor.checked};
     }
 
     ${Input}:disabled + & {
       cursor: not-allowed;
       color: #999;
-      --radio-state-color: ${radio.backgroundColor.disabled};
     }
   `}
 `;
@@ -48,16 +49,20 @@ const RadioButton = styled.span`
   display: grid;
   place-items: center;
   margin-right: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid var(--radio-border-color);
+  background-color: var(--radio-background-color);
 
-  ${({ theme: { radio } }) => css`
-    width: 16px;
-    height: 16px;
+  > span {
+    border-radius: inherit;
     background-color: #fff;
-    border-radius: ${radio.borderRadius};
-    border: 5px solid var(--radio-state-color);
-  `}
+    display: block;
+    width: 6px;
+    height: 6px;
+  }
 `;
-RadioButton.defaultProps = defaultProps;
 
 const Radio = forwardRef<HTMLInputElement, Props>(
   (
@@ -89,7 +94,9 @@ const Radio = forwardRef<HTMLInputElement, Props>(
           {...rest}
         />
         <InputContainer>
-          <RadioButton aria-hidden="true" />
+          <RadioButton aria-hidden="true">
+            <span />
+          </RadioButton>
           <span>{children}</span>
         </InputContainer>
       </label>

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -5,8 +5,7 @@ import { defaultProps } from '../../theme';
 export type Props = ComponentPropsWithRef<'input'>;
 
 const RadioWrapper = styled.div`
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
 `;
 RadioWrapper.defaultProps = defaultProps;
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -63,7 +63,6 @@ const Radio = forwardRef<HTMLInputElement, Props>(
   (
     {
       children,
-      className,
       id,
       name,
       value,

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -25,42 +25,41 @@ const Input = styled.input`
 `;
 Input.defaultProps = defaultProps;
 
+const Label = styled.label`
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+
+  ${({ theme: { radio } }) => css`
+    --radio-state-color: ${radio.backgroundColor.unchecked};
+
+    ${Input}:checked + & {
+      --radio-state-color: ${radio.backgroundColor.checked};
+    }
+
+    ${Input}:disabled + & {
+      cursor: not-allowed;
+      color: #999;
+      --radio-state-color: ${radio.backgroundColor.disabled};
+    }
+  `}
+`;
+Label.defaultProps = defaultProps;
+
 const RadioButton = styled.span`
   display: grid;
   place-items: center;
   margin-right: 4px;
 
   ${({ theme: { radio } }) => css`
-    --radio-state-color: ${radio.backgroundColor.unchecked};
-
     width: 16px;
     height: 16px;
     background-color: #fff;
     border-radius: ${radio.borderRadius};
     border: 5px solid var(--radio-state-color);
-
-    ${Input}:checked + ${Label} > & {
-      --radio-state-color: ${radio.backgroundColor.checked};
-    }
-
-    ${Input}:disabled + ${Label} > & {
-      --radio-state-color: ${radio.backgroundColor.disabled};
-    }
   `}
 `;
 RadioButton.defaultProps = defaultProps;
-
-const Label = styled.label`
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-
-  ${Input}:disabled + & {
-    cursor: not-allowed;
-    color: #999;
-  }
-`;
-const LabelText = styled.span``;
 
 const Radio = forwardRef<HTMLInputElement, Props>(
   (
@@ -93,7 +92,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
       />
       <Label htmlFor={id}>
         <RadioButton aria-hidden="true" />
-        <LabelText>{children}</LabelText>
+        <span>{children}</span>
       </Label>
     </RadioWrapper>
   )

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -39,28 +39,21 @@ const RadioButton = styled.span`
   margin-right: 4px;
 
   ${({ theme: { radio } }) => css`
+    --radio-bg-color: ${radio.backgroundColor.unchecked};
+
     width: 16px;
     height: 16px;
     border-radius: ${radio.borderRadius};
-    background-color: ${radio.backgroundColor.unchecked};
-    border-width: ${radio.borderWidth.unchecked};
-    border-style: ${radio.borderStyle.unchecked};
-    border-color: ${radio.borderColor.unchecked};
-    /* pointer-events: none; */
+    background-color: var(--radio-bg-color);
+    border: 1px solid var(--radio-bg-color);
     box-sizing: border-box;
 
     ${Input}:checked + ${Label} > & {
-      background-color: ${radio.backgroundColor.checked};
-      border-width: ${radio.borderWidth.checked};
-      border-style: ${radio.borderStyle.checked};
-      border-color: ${radio.borderColor.checked};
+      --radio-bg-color: ${radio.backgroundColor.checked};
     }
 
     ${Input}:disabled + ${Label} > & {
-      background-color: ${radio.backgroundColor.disabled};
-      border-width: ${radio.borderWidth.disabled};
-      border-style: ${radio.borderStyle.disabled};
-      border-color: ${radio.borderColor.disabled};
+      --radio-bg-color: ${radio.backgroundColor.disabled};
     }
   `}
 `;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,19 +1,10 @@
-import { forwardRef } from 'react';
+import { forwardRef, ComponentPropsWithRef } from 'react';
 import styled, { css } from 'styled-components';
 import { defaultProps } from '../../theme';
 
 export type Props = {
-  name?: string;
-  checked?: boolean;
-  defaultChecked?: boolean;
-  value?: string;
-  disabled?: boolean;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onClick?: (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
-  children?: React.ReactNode;
-  className?: string;
   id: string;
-};
+} & ComponentPropsWithRef<'input'>;
 
 const RadioWrapper = styled.div`
   display: inline-flex;
@@ -23,6 +14,7 @@ RadioWrapper.defaultProps = defaultProps;
 
 const Input = styled.input`
   /* visually-hidden */
+  /* TODO: Should extract visually-hidden style as a utility style */
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;
@@ -43,10 +35,9 @@ const RadioButton = styled.span`
 
     width: 16px;
     height: 16px;
-    border-radius: ${radio.borderRadius};
     background-color: #fff;
+    border-radius: ${radio.borderRadius};
     border: 5px solid var(--radio-state-color);
-    box-sizing: border-box;
 
     ${Input}:checked + ${Label} > & {
       --radio-state-color: ${radio.backgroundColor.checked};
@@ -73,9 +64,34 @@ const Label = styled.label`
 const LabelText = styled.span``;
 
 const Radio = forwardRef<HTMLInputElement, Props>(
-  ({ children, className, id, ...rest }, ref) => (
+  (
+    {
+      children,
+      className,
+      id,
+      name,
+      value,
+      disabled,
+      defaultChecked,
+      onClick,
+      onChange,
+      ...rest
+    },
+    ref
+  ) => (
     <RadioWrapper>
-      <Input type="radio" id={id} ref={ref} {...rest} />
+      <Input
+        type="radio"
+        id={id}
+        ref={ref}
+        name={name}
+        value={value}
+        disabled={disabled}
+        defaultChecked={defaultChecked}
+        onClick={onClick}
+        onChange={onChange}
+        {...rest}
+      />
       <Label htmlFor={id}>
         <RadioButton />
         <LabelText>{children}</LabelText>
@@ -83,7 +99,6 @@ const Radio = forwardRef<HTMLInputElement, Props>(
     </RadioWrapper>
   )
 );
-
 Radio.displayName = 'Radio';
 
 export { Radio };

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -2,9 +2,7 @@ import { forwardRef, ComponentPropsWithRef } from 'react';
 import styled, { css } from 'styled-components';
 import { defaultProps } from '../../theme';
 
-export type Props = {
-  id: string;
-} & ComponentPropsWithRef<'input'>;
+export type Props = ComponentPropsWithRef<'input'>;
 
 const RadioWrapper = styled.div`
   display: inline-flex;
@@ -25,7 +23,7 @@ const Input = styled.input`
 `;
 Input.defaultProps = defaultProps;
 
-const Label = styled.label`
+const InputContainer = styled.div`
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -44,7 +42,7 @@ const Label = styled.label`
     }
   `}
 `;
-Label.defaultProps = defaultProps;
+InputContainer.defaultProps = defaultProps;
 
 const RadioButton = styled.span`
   display: grid;
@@ -78,22 +76,24 @@ const Radio = forwardRef<HTMLInputElement, Props>(
     ref
   ) => (
     <RadioWrapper>
-      <Input
-        type="radio"
-        id={id}
-        ref={ref}
-        name={name}
-        value={value}
-        disabled={disabled}
-        defaultChecked={defaultChecked}
-        onClick={onClick}
-        onChange={onChange}
-        {...rest}
-      />
-      <Label htmlFor={id}>
-        <RadioButton aria-hidden="true" />
-        <span>{children}</span>
-      </Label>
+      <label htmlFor={id}>
+        <Input
+          type="radio"
+          id={id}
+          ref={ref}
+          name={name}
+          value={value}
+          disabled={disabled}
+          defaultChecked={defaultChecked}
+          onClick={onClick}
+          onChange={onChange}
+          {...rest}
+        />
+        <InputContainer>
+          <RadioButton aria-hidden="true" />
+          <span>{children}</span>
+        </InputContainer>
+      </label>
     </RadioWrapper>
   )
 );

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -15,51 +15,32 @@ export type Props = {
   id: string;
 };
 
-const RadioWrapper = styled.span`
-  ${({ theme: { radio } }) => css`
-    position: relative;
-    display: inline-block;
-    width: ${radio.width};
-    height: ${radio.height};
-    margin-top: 2px;
-    margin-right: 4px;
-  `}
+const RadioWrapper = styled.div`
+  display: inline-flex;
+  align-items: center;
 `;
 RadioWrapper.defaultProps = defaultProps;
 
 const Input = styled.input`
-  ${({ theme: { radio } }) => css`
-    /* opacity: 0;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    cursor: pointer; */
-
-    :checked + ${RadioButton} {
-      background-color: ${radio.backgroundColor.checked};
-      border-width: ${radio.borderWidth.checked};
-      border-style: ${radio.borderStyle.checked};
-      border-color: ${radio.borderColor.checked};
-    }
-
-    :disabled + ${RadioButton} {
-      background-color: ${radio.backgroundColor.disabled};
-      border-width: ${radio.borderWidth.disabled};
-      border-style: ${radio.borderStyle.disabled};
-      border-color: ${radio.borderColor.disabled};
-    }
-  `}
+  /* visually-hidden */
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 `;
 Input.defaultProps = defaultProps;
 
 const RadioButton = styled.span`
+  display: grid;
+  place-items: center;
+  margin-right: 4px;
+
   ${({ theme: { radio } }) => css`
-    /* position: absolute;
-    width: 100%;
-    height: 100%; */
+    width: 16px;
+    height: 16px;
     border-radius: ${radio.borderRadius};
     background-color: ${radio.backgroundColor.unchecked};
     border-width: ${radio.borderWidth.unchecked};
@@ -67,19 +48,29 @@ const RadioButton = styled.span`
     border-color: ${radio.borderColor.unchecked};
     /* pointer-events: none; */
     box-sizing: border-box;
+
+    ${Input}:checked + ${Label} > & {
+      background-color: ${radio.backgroundColor.checked};
+      border-width: ${radio.borderWidth.checked};
+      border-style: ${radio.borderStyle.checked};
+      border-color: ${radio.borderColor.checked};
+    }
+
+    ${Input}:disabled + ${Label} > & {
+      background-color: ${radio.backgroundColor.disabled};
+      border-width: ${radio.borderWidth.disabled};
+      border-style: ${radio.borderStyle.disabled};
+      border-color: ${radio.borderColor.disabled};
+    }
   `}
 `;
 RadioButton.defaultProps = defaultProps;
 
 const IconWrapper = styled.span`
   ${({ theme: { radio } }) => css`
-    position: absolute;
     display: inline-block;
-    top: 50%;
-    left: 50%;
     width: ${radio.icon.width};
     height: ${radio.icon.height};
-    transform: translate(-50%, -50%);
     /* pointer-events: none; */
 
     & > svg {
@@ -94,6 +85,7 @@ const Icon = styled(({ className }) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 6 6"
     className={className}
+    aria-hidden="true"
   >
     <circle
       cx="102"
@@ -105,12 +97,7 @@ const Icon = styled(({ className }) => (
   </svg>
 ))`
   ${({ theme: { radio } }) => css`
-    width: ${radio.icon.width};
-    height: ${radio.icon.height};
-
-    & > circle {
-      fill: ${radio.icon.color};
-    }
+    fill: ${radio.icon.color};
   `}
 `;
 Icon.defaultProps = defaultProps;
@@ -118,33 +105,24 @@ Icon.defaultProps = defaultProps;
 const Label = styled.label`
   cursor: pointer;
   display: inline-flex;
-  align-items: flex-start;
+  align-items: center;
 `;
 
 const LabelText = styled.span``;
 
 const Radio = forwardRef<HTMLInputElement, Props>(
   ({ children, className, id, ...rest }, ref) => (
-    // <Label>
-    //   <RadioWrapper className={className}>
-    //     <Input type="radio" ref={ref} {...rest} />
-    //     <Box />
-    //     <IconWrapper>
-    //       <Icon />
-    //     </IconWrapper>
-    //   </RadioWrapper>
-    //   <LabelText>{children}</LabelText>
-    // </Label>
-    <div>
+    <RadioWrapper>
       <Input type="radio" id={id} ref={ref} {...rest} />
       <Label htmlFor={id}>
-        <RadioButton />
-        <IconWrapper>
-          <Icon />
-        </IconWrapper>
+        <RadioButton>
+          <IconWrapper>
+            <Icon />
+          </IconWrapper>
+        </RadioButton>
         <LabelText>{children}</LabelText>
       </Label>
-    </div>
+    </RadioWrapper>
   )
 );
 

--- a/src/components/Radio/__tests__/Radio.test.tsx
+++ b/src/components/Radio/__tests__/Radio.test.tsx
@@ -4,7 +4,7 @@ import { Radio } from '../Radio';
 
 describe('Radio', () => {
   it('default', () => {
-    const { asFragment } = render(<Radio>radio</Radio>);
+    const { asFragment } = render(<Radio id="radio-1">radio</Radio>);
     expect(asFragment()).toMatchSnapshot();
 
     const radio = screen.getByRole('radio');
@@ -13,12 +13,20 @@ describe('Radio', () => {
   });
 
   it('defaultChecked props', () => {
-    render(<Radio defaultChecked={true}>radio</Radio>);
+    render(
+      <Radio id="radio-1" defaultChecked={true}>
+        radio
+      </Radio>
+    );
     expect(screen.getByRole('radio')).toBeChecked();
   });
 
   it('disabled props', () => {
-    render(<Radio disabled={true}>radio</Radio>);
+    render(
+      <Radio id="radio-1" disabled={true}>
+        radio
+      </Radio>
+    );
     expect(screen.getByRole('radio')).toBeDisabled();
   });
 
@@ -26,7 +34,7 @@ describe('Radio', () => {
     const onChange = jest.fn();
     const onClick = jest.fn();
     render(
-      <Radio onChange={onChange} onClick={onClick}>
+      <Radio id="radio-1" onChange={onChange} onClick={onClick}>
         radio
       </Radio>
     );
@@ -44,7 +52,7 @@ describe('Radio', () => {
       };
 
       return (
-        <Radio checked={checked} onChange={handleChange}>
+        <Radio id="radio-1" checked={checked} onChange={handleChange}>
           radio
         </Radio>
       );

--- a/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -2,127 +2,88 @@
 
 exports[`Radio default 1`] = `
 <DocumentFragment>
-  .c1 {
-  position: relative;
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  margin-top: 2px;
-  margin-right: 4px;
+  .c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c2 {
-  opacity: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  cursor: pointer;
-}
-
-.c2:checked + .c3 {
-  background-color: #3B7DE9;
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c2:disabled + .c3 {
-  background-color: #D4D8DD;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #D4D8DD;
-}
-
-.c4 {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  background-color: #FFFFFF;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #D4D8DD;
-  pointer-events: none;
-  box-sizing: border-box;
-}
-
-.c5 {
-  position: absolute;
-  display: inline-block;
-  top: 50%;
-  left: 50%;
-  width: 6px;
-  height: 6px;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  pointer-events: none;
-}
-
-.c5 > svg {
-  vertical-align: top;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .c6 {
-  width: 6px;
-  height: 6px;
+  display: grid;
+  place-items: center;
+  margin-right: 4px;
+  --radio-state-color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  background-color: #fff;
+  border-radius: 8px;
+  border: 5px solid var(--radio-state-color);
 }
 
-.c6 > circle {
-  fill: #FFFFFF;
+.c1:checked + .c3 > .c5 {
+  --radio-state-color: #3B7DE9;
 }
 
-.c0 {
+.c1:disabled + .c3 > .c5 {
+  --radio-state-color: #D4D8DD;
+}
+
+.c4 {
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
-<label
+.c1:disabled + .c3 {
+  cursor: not-allowed;
+  color: #999;
+}
+
+<div
     class="c0"
   >
-    <span
-      class="c1"
+    <input
+      class="c1 c2"
+      id="radio-1"
+      type="radio"
+      value=""
+    />
+    <label
+      class="c3 c4"
+      for="radio-1"
     >
-      <input
-        class="c2"
-        type="radio"
+      <span
+        class="c5 c6"
       />
       <span
-        class="c3 c4"
-      />
-      <span
-        class="c5"
+        class=""
       >
-        <svg
-          class="c6"
-          viewBox="0 0 6 6"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle
-            cx="102"
-            cy="546"
-            fill-rule="evenodd"
-            r="3"
-            transform="translate(-99 -543)"
-          />
-        </svg>
+        radio
       </span>
-    </span>
-    <span
-      class=""
-    >
-      radio
-    </span>
-  </label>
+    </label>
+  </div>
 </DocumentFragment>
 `;

--- a/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -3,14 +3,7 @@
 exports[`Radio default 1`] = `
 <DocumentFragment>
   .c0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  display: inline-block;
 }
 
 .c2 {
@@ -35,17 +28,18 @@ exports[`Radio default 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  --radio-state-color: #FFFFFF;
+  --radio-background-color: #FFFFFF;
+  --radio-border-color: #D4D8DD;
 }
 
 .c1:checked + .c3 {
-  --radio-state-color: #3B7DE9;
+  --radio-background-color: #3B7DE9;
+  --radio-border-color: rgba(0,0,0,0.15);
 }
 
 .c1:disabled + .c3 {
   cursor: not-allowed;
   color: #999;
-  --radio-state-color: #D4D8DD;
 }
 
 .c5 {
@@ -54,9 +48,17 @@ exports[`Radio default 1`] = `
   margin-right: 4px;
   width: 16px;
   height: 16px;
+  border-radius: 50%;
+  border: 1px solid var(--radio-border-color);
+  background-color: var(--radio-background-color);
+}
+
+.c5 > span {
+  border-radius: inherit;
   background-color: #fff;
-  border-radius: 8px;
-  border: 5px solid var(--radio-state-color);
+  display: block;
+  width: 6px;
+  height: 6px;
 }
 
 <div
@@ -77,7 +79,9 @@ exports[`Radio default 1`] = `
         <span
           aria-hidden="true"
           class="c5"
-        />
+        >
+          <span />
+        </span>
         <span>
           radio
         </span>

--- a/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -25,26 +25,6 @@ exports[`Radio default 1`] = `
   width: 1px;
 }
 
-.c6 {
-  display: grid;
-  place-items: center;
-  margin-right: 4px;
-  --radio-state-color: #FFFFFF;
-  width: 16px;
-  height: 16px;
-  background-color: #fff;
-  border-radius: 8px;
-  border: 5px solid var(--radio-state-color);
-}
-
-.c1:checked + .c3 > .c5 {
-  --radio-state-color: #3B7DE9;
-}
-
-.c1:disabled + .c3 > .c5 {
-  --radio-state-color: #D4D8DD;
-}
-
 .c4 {
   cursor: pointer;
   display: -webkit-inline-box;
@@ -55,34 +35,53 @@ exports[`Radio default 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  --radio-state-color: #FFFFFF;
+}
+
+.c1:checked + .c3 {
+  --radio-state-color: #3B7DE9;
 }
 
 .c1:disabled + .c3 {
   cursor: not-allowed;
   color: #999;
+  --radio-state-color: #D4D8DD;
+}
+
+.c5 {
+  display: grid;
+  place-items: center;
+  margin-right: 4px;
+  width: 16px;
+  height: 16px;
+  background-color: #fff;
+  border-radius: 8px;
+  border: 5px solid var(--radio-state-color);
 }
 
 <div
     class="c0"
   >
-    <input
-      class="c1 c2"
-      id="radio-1"
-      type="radio"
-      value=""
-    />
     <label
-      class="c3 c4"
       for="radio-1"
     >
-      <span
-        class="c5 c6"
+      <input
+        class="c1 c2"
+        id="radio-1"
+        type="radio"
+        value=""
       />
-      <span
-        class=""
+      <div
+        class="c3 c4"
       >
-        radio
-      </span>
+        <span
+          aria-hidden="true"
+          class="c5"
+        />
+        <span>
+          radio
+        </span>
+      </div>
     </label>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
## 概要

ラジオボタンのdisabled時の振る舞いを修正します。

- disabled時はテキストカラーを `#999` にする
- disabled時はカーソル操作不可であることを示す。`cursor-pointer: not-allowed`

左から chrome, Firefox, Safari

![image](https://user-images.githubusercontent.com/5795937/133071975-fe9bd431-f07d-4311-b927-bfc96d91781f.png)

## 対応内容

CSSセレクタを活用して、checkedやdisabledの状態を管理します。
そのためにHTMLとCSSのリファクタリングを行っています。

#### リファクタリング内容

   - 構造を整理して不要なスタイルとHTMLを削除
   -  radioボタンの表示をsvgからdiv要素に変更(CSSで描画)
   - Propsは `ComponentPropsWithRef<'input'>` を使い一般的なInputの属性をカバーする

## レビュー箇所

- disabledの振る舞いが実現できているか