### PR TITLE
Fix auto deploy Storybook to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,4 +13,6 @@ jobs:
         with:
           cache: npm
       - run: npm ci
-      - run: npm run storybook:deploy
+      - run: npm run storybook:deploy -- --ci
+        env:
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
ref: https://github.com/storybookjs/storybook-deployer/issues/77
`GH_TOKEN` envにGitHubのtokenを指定するのが必要でした。

試しにdeployして成功しました。
https://github.com/moneyforward/cloud-react-ui/runs/3608480364?check_suite_focus=true

![image](https://user-images.githubusercontent.com/5629074/133433887-1708b432-3af0-4b6c-8bf1-368910f7d796.png)
