### PR TITLE
addded size prop to CircularProgress

### DIFF
--- a/src/components/CircularProgress/CircularProgress.tsx
+++ b/src/components/CircularProgress/CircularProgress.tsx
@@ -5,6 +5,7 @@ import { defaultProps } from '../../theme';
 
 export type Props = {
   className?: string;
+  size?: number | string;
 };
 
 const StyledCircularProgress = styled(MuiCircularProgress)`

--- a/src/components/CircularProgress/__tests__/CircularProgress.test.tsx
+++ b/src/components/CircularProgress/__tests__/CircularProgress.test.tsx
@@ -1,9 +1,22 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { CircularProgress } from '../CircularProgress';
 
 describe('CircularProgress', () => {
   it('snapshot test', () => {
     const { asFragment } = render(<CircularProgress />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it.each([
+    {
+      size: '3rem',
+    },
+    { size: 10 },
+  ])('changes the size to $size', ({ size }) => {
+    const { asFragment } = render(<CircularProgress size={size} />);
+    const sizeWithUnit = typeof size === 'string' ? size : `${size}px`;
+    const expected = `height: ${sizeWithUnit}; width: ${sizeWithUnit}`;
+
+    expect(screen.getByRole('progressbar')).toHaveStyle(expected);
   });
 });


### PR DESCRIPTION
https://material-ui.com/api/circular-progress/#props

- size propを追加しましたら、sizeを調整できます（styled componentsにheight/width調整はできなさそうでした）。

![Kapture 2021-09-16 at 18 28 48](https://user-images.githubusercontent.com/25769723/133587912-f2df46e2-f284-4262-a59b-2c659ee79ae8.gif)
